### PR TITLE
pr feat/#36-main-page-stock-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
         "react-financial-charts": "^2.0.1",
+        "react-query": "^3.39.3",
         "react-router-dom": "^7.2.0",
         "styled-components": "^6.1.15"
       },
@@ -263,6 +264,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2186,14 +2198,20 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2209,6 +2227,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -2406,8 +2439,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2751,6 +2783,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3403,6 +3440,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3513,6 +3555,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3698,6 +3760,21 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4104,6 +4181,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4246,6 +4328,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.4.tgz",
+      "integrity": "sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "remove-accents": "0.5.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4276,6 +4367,11 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4299,7 +4395,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4312,6 +4407,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -4442,6 +4545,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4525,6 +4641,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4741,6 +4865,31 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-query": {
+      "version": "3.39.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.3.tgz",
+      "integrity": "sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -4819,6 +4968,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -4838,6 +4992,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -4873,6 +5032,21 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -5545,6 +5719,15 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -5762,6 +5945,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "react-financial-charts": "^2.0.1",
+    "react-query": "^3.39.3",
     "react-router-dom": "^7.2.0",
     "styled-components": "^6.1.15"
   },

--- a/src/apis/stock.ts
+++ b/src/apis/stock.ts
@@ -91,3 +91,9 @@ export const deleteCommentAPI = async (
   
   return response.data;
 };
+
+// 전체 섹터 조회 API 연결
+export const getSectorsAPI = async (): Promise<APIResponse<string[]>> => {
+  const response = await stockAPI.get<APIResponse<string[]>>("/sectors");
+  return response.data;
+};

--- a/src/apis/stock.ts
+++ b/src/apis/stock.ts
@@ -1,4 +1,6 @@
 import { APIResponse, stockAPI } from ".";
+import { SnowflakeItems } from "../types/snowflakeTypes";
+import { FilterStock } from "../types/stockTypes";
 
 // 1) 개별 종목 검색 (자동완성)
 export interface AutocompleteStock {
@@ -95,5 +97,22 @@ export const deleteCommentAPI = async (
 // 전체 섹터 조회 API 연결
 export const getSectorsAPI = async (): Promise<APIResponse<string[]>> => {
   const response = await stockAPI.get<APIResponse<string[]>>("/sectors");
+  return response.data;
+};
+
+// 조건 검색 결과 조회
+export interface FilterStocksPayload {
+  marketType: "ALL" | "KOSPI" | "KOSDAQ";
+  sector?: string[];
+  filters: Partial<SnowflakeItems>;
+}
+
+export const getFilterStocksAPI = async (
+  payload: FilterStocksPayload
+): Promise<APIResponse<FilterStock[]>> => {
+  const response = await stockAPI.post<APIResponse<FilterStock[]>>(
+    "/filter",
+    payload
+  );
   return response.data;
 };

--- a/src/components/stock/grid/StockGrid.tsx
+++ b/src/components/stock/grid/StockGrid.tsx
@@ -16,7 +16,7 @@ const StockGrid = ({ stocks, setStocks, onToggleBookmark }: StockProps) => {
       {stocks.map((stock) => {
         // 각 주식의 스노우플레이크 데이터가 있다면 Item 배열로 변환
         const snowflakeItems: Item[] = stock.snowflakeS
-          ? Object.entries(stock.snowflakeS.elements).map(([key, values]) => ({
+          ? Object.entries(stock.snowflakeS).map(([key, values]) => ({
               key,
               label: labelMapping[key] ?? key,
               D2Value: values,
@@ -26,7 +26,7 @@ const StockGrid = ({ stocks, setStocks, onToggleBookmark }: StockProps) => {
 
         // 각 주식의 스노우플레이크 요소의 키 목록
         const snowflakeSelectedKeys: string[] = stock.snowflakeS
-          ? Object.keys(stock.snowflakeS.elements)
+          ? Object.keys(stock.snowflakeS)
           : [];
 
         return (

--- a/src/components/stock/grid/card/StockCard.tsx
+++ b/src/components/stock/grid/card/StockCard.tsx
@@ -1,14 +1,14 @@
 import Bookmark from "../../../bookmark/Bookmark";
 import * as S from "./StockCard.styled";
 import { getRandomColor } from "../../../../utils/colorUtils";
-import { Stock } from "../../../../types/stockTypes";
+import { FilterStock } from "../../../../types/stockTypes";
 import { Item } from "../../../../types/snowflakeTypes";
 import StockSnowflake from "../../../snowflake/StockSnowflake";
 
 export interface StockCardProps {
-  stock: Stock;
-  stocks: Stock[];
-  setStocks: React.Dispatch<React.SetStateAction<Stock[]>>;
+  stock: FilterStock;
+  stocks: FilterStock[];
+  setStocks: React.Dispatch<React.SetStateAction<FilterStock[]>>;
   allItems: Item[];
   selectedKeys: string[];
   onToggleBookmark: (stockId: number, newState: boolean) => void;
@@ -34,7 +34,7 @@ const StockCard = ({
         <S.CardHeaderRight>
           <Bookmark
             stockId={stock.stockId}
-            isBookmarked={stock.isBookmark}
+            isBookmarked={stock.fav}
             onToggleBookmark={onToggleBookmark}
           />
         </S.CardHeaderRight>
@@ -43,7 +43,7 @@ const StockCard = ({
       <S.CardContent>
         {/* 앞면: 줄임표 설명 + 이미지 */}
         <S.FrontContent className="front">
-          <S.ShortDescription>{stock.description}</S.ShortDescription>
+          <S.ShortDescription>{stock.companyOverview}</S.ShortDescription>
           <S.CardImgWrapper>
             <StockSnowflake
               allItems={allItems}
@@ -55,7 +55,7 @@ const StockCard = ({
 
         {/* 뒷면: 더 많은 텍스트 (이미지 없이) */}
         <S.BackContent className="back">
-          <S.LongDescription>{stock.description}</S.LongDescription>
+          <S.LongDescription>{stock.companyOverview}</S.LongDescription>
         </S.BackContent>
       </S.CardContent>
 
@@ -66,14 +66,14 @@ const StockCard = ({
         </S.CardFooterItem>
         <S.CardFooterItem>
           <S.CardFooterTitle>7D</S.CardFooterTitle>
-          <S.CardFooterChange $isPositive={stock["1WeekFluctuationRate"] >= 0}>
-            {stock["1WeekFluctuationRate"]}%
+          <S.CardFooterChange $isPositive={stock.weekRateChange >= 0}>
+            {stock.weekRateChange}%
           </S.CardFooterChange>
         </S.CardFooterItem>
         <S.CardFooterItem>
           <S.CardFooterTitle>1Y</S.CardFooterTitle>
-          <S.CardFooterChange $isPositive={stock["1YearFluctuationRate"] >= 0}>
-            {stock["1YearFluctuationRate"]}%
+          <S.CardFooterChange $isPositive={stock.yearRateChange >= 0}>
+            {stock.yearRateChange}%
           </S.CardFooterChange>
         </S.CardFooterItem>
       </S.CardFooter>

--- a/src/components/stock/list/StockList.tsx
+++ b/src/components/stock/list/StockList.tsx
@@ -1,13 +1,13 @@
 import * as S from "./StockList.styled";
 import Bookmark from "../../bookmark/Bookmark";
 import { useNavigate } from "react-router-dom";
-import { Stock } from "../../../types/stockTypes";
+import { FilterStock } from "../../../types/stockTypes";
 import { labelMapping } from "../../../types/snowflakeTypes";
 import StockSnowflake from "../../snowflake/StockSnowflake";
 
 export interface StockProps {
-  stocks: Stock[];
-  setStocks: React.Dispatch<React.SetStateAction<Stock[]>>;
+  stocks: FilterStock[];
+  setStocks: React.Dispatch<React.SetStateAction<FilterStock[]>>;
   onToggleBookmark: (stockId: number, newState: boolean) => void;
 }
 
@@ -38,19 +38,17 @@ const StockList = ({ stocks, onToggleBookmark }: StockProps) => {
         {stocks.map((stock) => {
           // 각 주식의 스노우플레이크 데이터가 있다면 Item 배열로 변환
           const snowflakeItems = stock.snowflakeS
-            ? Object.entries(stock.snowflakeS.elements).map(
-                ([key, values]) => ({
-                  key,
-                  label: labelMapping[key] ?? key,
-                  D2Value: values,
-                  D1Value: values,
-                })
-              )
+            ? Object.entries(stock.snowflakeS).map(([key, values]) => ({
+                key,
+                label: labelMapping[key] ?? key,
+                D2Value: values,
+                D1Value: values,
+              }))
             : [];
 
           // 각 주식의 스노우플레이크 요소의 키 목록
           const snowflakeSelectedKeys = stock.snowflakeS
-            ? Object.keys(stock.snowflakeS.elements)
+            ? Object.keys(stock.snowflakeS)
             : [];
 
           return (
@@ -77,22 +75,24 @@ const StockList = ({ stocks, onToggleBookmark }: StockProps) => {
               </td>
               <td>₩{stock.currentPrice}</td>
 
-              <S.ChangeTd $isPositive={stock["1WeekFluctuationRate"] >= 0}>
-                {stock["1WeekFluctuationRate"]}
+              <S.ChangeTd $isPositive={stock.weekRateChange >= 0}>
+                {stock.weekRateChange}
               </S.ChangeTd>
 
-              <S.ChangeTd $isPositive={stock["1YearFluctuationRate"] >= 0}>
-                {stock["1YearFluctuationRate"]}%
+              <S.ChangeTd $isPositive={stock.yearRateChange >= 0}>
+                {stock.yearRateChange}%
               </S.ChangeTd>
-              <td>{stock.marketCap}</td>
+              {/* marketCap으로 바꾸기 */}
               <td>{stock.per}</td>
-              <td>{stock.debtRate}%</td>
+              <td>{stock.per}</td>
+              {/* debtRate 로 바꾸기 */}
+              <td>{stock.per}%</td>
               <td>{stock.sector}</td>
               <td onClick={(e) => e.stopPropagation}>
                 <S.BookmarkWrapper>
                   <Bookmark
                     stockId={stock.stockId}
-                    isBookmarked={stock.isBookmark}
+                    isBookmarked={stock.fav}
                     onToggleBookmark={onToggleBookmark}
                   />
                 </S.BookmarkWrapper>

--- a/src/components/stock/result/StockResult.tsx
+++ b/src/components/stock/result/StockResult.tsx
@@ -9,22 +9,15 @@ import StockGrid from "../grid/StockGrid";
 import SortDropdown from "../../sortDropdown/SortDropdown";
 import SortKeyIcon from "../../../assets/images/icons/sortKey.png";
 import SortDirectionIcon from "../../../assets/images/icons/sortDirection.png";
-import { Stock } from "../../../types/stockTypes";
-
-export interface StockResultData {
-  stockCnt: number;
-  stockInfos: Stock[];
-  portfolioTitle?: string;
-  portfolioDescription?: string;
-}
+import { FilterStock } from "../../../types/stockTypes";
 
 // StockResult 컴포넌트 Props 정의
 interface StockResultProps {
-  data: StockResultData;
+  data: FilterStock[];
 }
 
 const StockResult = ({ data }: StockResultProps) => {
-  const [stocks, setStocks] = useState<Stock[]>(data.stockInfos);
+  const [stocks, setStocks] = useState<FilterStock[]>(data);
   const [view, setView] = useState("list");
   const [sortKey, setSortKey] = useState("시가총액");
   const [sortDirection, setSortDirection] = useState("내림차순");
@@ -120,7 +113,7 @@ const StockResult = ({ data }: StockResultProps) => {
       {view === "list" ? (
         <>
           <StockList
-            stocks={stocks}
+            stocks={data}
             setStocks={setStocks}
             onToggleBookmark={handleToggleBookmark}
           />
@@ -128,7 +121,7 @@ const StockResult = ({ data }: StockResultProps) => {
       ) : (
         <>
           <StockGrid
-            stocks={stocks}
+            stocks={data}
             setStocks={setStocks}
             onToggleBookmark={handleToggleBookmark}
           />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,14 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   // <StrictMode>
-  <App />
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>
   // </StrictMode>,
 );

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -181,7 +181,7 @@ const MainPage: React.FC = () => {
 
   useEffect(() => {
     handleFilterStocks();
-  }, [selectedKeys, marketFilter, selectedSectorKeys, allItems]);
+  }, [selectedKeys, marketFilter, selectedSectorKeys]);
 
   // [API] 조건 검색 결과 조회
   const handleFilterStocks = async () => {
@@ -223,6 +223,11 @@ const MainPage: React.FC = () => {
     } catch (error) {
       console.error("필터 API 호출 실패:", error);
     }
+  };
+
+  // 드래그 종료 시점에만 호출할 함수
+  const handleSnowflakeDragEnd = () => {
+    handleFilterStocks();
   };
 
   return (
@@ -318,6 +323,7 @@ const MainPage: React.FC = () => {
                 allItems={allItems}
                 setAllItems={setAllItems}
                 selectedKeys={selectedKeys}
+                onSnowflakeDragEnd={handleSnowflakeDragEnd}
               />
             </S.MainPageSnowflake>
           </S.MainPageSnowflakeWrapper>

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -231,6 +231,11 @@ const MainPage: React.FC = () => {
 
   const handleSavePortfolio = async () => {
     try {
+      if (!portfolioTitle.trim() || !portfolioDesc.trim()) {
+        alert("포트폴리오 제목과 설명은 필수 입력 사항입니다.");
+        return;
+      }
+
       const reverseMapping = Object.entries(labelMapping).reduce(
         (acc, [eng, kor]) => {
           acc[kor] = eng;

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "./constants/defaultFilterItems";
 import { labelMapping } from "../../types/snowflakeTypes";
 import { useNavigate } from "react-router-dom";
+import { useSectors } from "./hooks/useSectors";
 
 //더미데이터
 const dummyStockResponse = {
@@ -149,28 +150,8 @@ const MainPage: React.FC = () => {
   const [marketFilter, setMarketFilter] = useState<string>("전체");
 
   // 4) 섹터 필터 항목
-  const sectors = [
-    "반도체",
-    "금융",
-    "헬스케어",
-    "자동차",
-    "IT",
-    "에너지",
-    "화학",
-    "바이오",
-    "통신",
-    "유통",
-    "부동산",
-    "소비재",
-    "제약",
-    "건설",
-    "농업",
-    "공업",
-    "전자",
-    "서비스",
-    "교육",
-    "문화",
-  ];
+  const { data: sectorsData } = useSectors();
+  const sectors = sectorsData?.data ?? [];
 
   const [selectedSectorKeys, setSelectedSectorKeys] = useState<string[]>([]);
   const [recommendedPortfolios, setRecommendedPortfolios] = useState<

--- a/src/pages/mainPage/components/snowflake/Snowflake.tsx
+++ b/src/pages/mainPage/components/snowflake/Snowflake.tsx
@@ -15,12 +15,14 @@ interface SnowflakeProps {
   allItems: Item[];
   setAllItems: React.Dispatch<React.SetStateAction<Item[]>>;
   selectedKeys: string[];
+  onSnowflakeDragEnd?: () => void;
 }
 
 const Snowflake: React.FC<SnowflakeProps> = ({
   allItems,
   setAllItems,
   selectedKeys,
+  onSnowflakeDragEnd,
 }) => {
   // 3) 필터링된 항목들
   const filteredItems = useMemo(() => {
@@ -146,21 +148,8 @@ const Snowflake: React.FC<SnowflakeProps> = ({
           ) => {
             handleDrag(datasetIndex, index, value);
           },
-          onDragEnd: (
-            event: any,
-            datasetIndex: number,
-            index: number,
-            value: number | null
-          ) => {
-            console.log("drag end", { event, datasetIndex, index, value });
-          },
-          onDragStart: (
-            event: any,
-            datasetIndex: number,
-            index: number,
-            value: number | null
-          ) => {
-            console.log("drag start", { event, datasetIndex, index, value });
+          onDragEnd: () => {
+            onSnowflakeDragEnd?.();
           },
         },
         legend: {

--- a/src/pages/mainPage/hooks/useFilterStocks.ts
+++ b/src/pages/mainPage/hooks/useFilterStocks.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "react-query";
+import { getFilterStocksAPI, FilterStocksPayload } from "../../../apis/stock";
+import { APIResponse } from "../../../apis";
+import { FilterStock } from "../../../types/stockTypes";
+
+export const useFilterStocks = () => {
+  return useMutation<APIResponse<FilterStock[]>, Error, FilterStocksPayload>(
+    (payload: FilterStocksPayload) => getFilterStocksAPI(payload)
+  );
+};

--- a/src/pages/mainPage/hooks/useSectors.ts
+++ b/src/pages/mainPage/hooks/useSectors.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "react-query";
+import { getSectorsAPI } from "../../../apis/stock";
+
+export const useSectors = () => {
+  return useQuery({
+    queryKey: ["sectors"],
+    queryFn: getSectorsAPI,
+    staleTime: 24 * 60 * 60 * 1000, // 24시간
+    cacheTime: 24 * 60 * 60 * 1000,
+    onError: (error) => {
+      console.error("섹터 데이터를 불러오는데 실패했습니다.", error);
+    },
+  });
+};

--- a/src/pages/portfolioPage/PortfolioPage.tsx
+++ b/src/pages/portfolioPage/PortfolioPage.tsx
@@ -1,10 +1,16 @@
 import * as S from "./PortfolioPage.styled";
-import StockResult, {
-  StockResultData,
-} from "../../components/stock/result/StockResult";
+import StockResult from "../../components/stock/result/StockResult";
 import { transformElementsToItems } from "../../utils/snowflakeUtils";
 import PortfolioSnowflake from "../../components/snowflake/PortfolioSnowflake";
 import LineGraph from "../../components/lineGraph/LineGraph";
+import { Stock } from "../../types/stockTypes";
+
+export interface StockResultData {
+  stockCnt: number;
+  stockInfos: Stock[];
+  portfolioTitle?: string;
+  portfolioDescription?: string;
+}
 
 // 더미 데이터 : 나의 포트폴리오 종목 리스트 조회 + 포트폴리오명 & 설명
 const dummyPortfolioResponse = {
@@ -217,7 +223,7 @@ const PortfolioPage = () => {
       </S.PortfolioContent>
 
       <S.PortfolioStock>
-        <StockResult data={stockResultData} />
+        {/* <StockResult data={stockResultData} /> */}
       </S.PortfolioStock>
     </S.PortfolioPageContainer>
   );

--- a/src/types/stockTypes.ts
+++ b/src/types/stockTypes.ts
@@ -1,4 +1,4 @@
-import { SnowflakeP, SnowflakeS } from "./snowflakeTypes";
+import { SnowflakeP, SnowflakeS, SnowflakeSElements } from "./snowflakeTypes";
 
 export interface Stock {
   stockId: number;
@@ -49,4 +49,19 @@ export interface Competitor {
     divYield: number;
     foreignerRatio: number;
   };
+}
+
+export interface FilterStock extends SnowflakeSElements {
+  stockId: number;
+  ticker: string;
+  marketType: "ALL" | "KOSPI" | "KOSDAQ";
+  companyName: string;
+  sector: string;
+  companyOverview: string;
+  snowflakeS: Partial<SnowflakeSElements>;
+  weekRateChange: number;
+  yearRateChange: number;
+  currentPrice: number;
+  changeRate: number;
+  fav: boolean;
 }


### PR DESCRIPTION
메인 페이지에서 stock과 관련된 API를 연결했습니다. 
API 명세서의 response 형태가 바뀌는 과정에서 기존 포트폴리오 페이지의 StockResult 컴포넌트를 사용하는 부분에 변경이 필요해보입니다.
해당 API를 연결할 때, PortfolioPage.tsx의 StockResult 컴포넌트의 주석을 해제한 후, 변경 바랍니다.

- 전체 섹터 조회 API 연결 완료
- 조건 검색 결과 조회 API 연결 완료
(아래에 내용은 추후 구현이 필요한 부분입니다.)
  * debtRate, marketCap, 전체 데이터 몇 개 인지 response 필요
  * 무한 스크롤 적용 필요
  * Loading 스피너 적용 필요
  * 섹터 전체 선택 디자인 변경 필요
  * 검색 결과 없을 때 예외처리 필요 
