### PR TITLE
pr feat/#56-modify-search-autocomplete

### DIFF
--- a/src/apis/stock.ts
+++ b/src/apis/stock.ts
@@ -12,8 +12,9 @@ export interface AutocompleteStock {
 export const autocompleteAPI = async (
   keyword: string
 ): Promise<AutocompleteStock[]> => {
-  const response = await stockAPI.get<APIResponse<AutocompleteStock[]>>(
-    `/search?keyword=${keyword}`
+  const response = await stockAPI.post<APIResponse<AutocompleteStock[]>>(
+    `/search`,
+    { keyword }
   );
   const stocks = response.data.data;
   return Array.isArray(stocks) ? stocks : [];


### PR DESCRIPTION
개별 종목 검색 (자동완성) API 형식이 수정된대로, 요청 파라미터가 아닌 request body로 키워드를 보냅니다.